### PR TITLE
Add index page for the resources area of the platform

### DIFF
--- a/src/resources/resources.md
+++ b/src/resources/resources.md
@@ -1,0 +1,7 @@
+# Resources
+
+Resources that can shared between, and used by, multiple automation projects and apps. The following are the available types:
+
+* :docs-link[Datastores]{id="resources/datastores/datastores"}
+* :docs-link[Listeners]{id="resources/listener"}
+* :docs-link[CMS]{id="resources/cms/cms"}


### PR DESCRIPTION
Add an index page for the resources are of the platform. This will enable us to have a single docs link on that page, resolving an issue we currently have with the table layout not having docs links