### PR TITLE
Use 'datastore variable' over 'datastore parameter' across the docs for clarity

### DIFF
--- a/src/projects/apps/designer/data_sidebar.md
+++ b/src/projects/apps/designer/data_sidebar.md
@@ -1,21 +1,21 @@
 # Data Sidebar
 
-The data sidebar is a quick way, within the app designer, to access your app resources. 
+The data sidebar is a quick way, within the app designer, to access your app resources.
 
 ![Data sidebar](/src/assets/datasidebar_collapsed.png)
 
-The data sidebar can be found on the left hand side of the designer. Here you will find all your CMS, Datastores and Listeners you have as resources to your app. 
+The data sidebar can be found on the left hand side of the designer. Here you will find all your CMS, Datastores and Listeners you have as resources to your app.
 
 ![Data sidebar showing items for all resources](/src/assets/datasidebar_open.png)
 
 Opening each of the resources will show the relavent data. To use any of the data inside of the app you can simply drag items onto the page. This will open up a wizard which will guide you into selecting a component to use. The items you can drag onto the page are:
 - CMS fields
-- Datastore parameters 
+- Datastore variables
 - Listener (by dragging the listener icon)
 - Listener outputs
 
-![The wizard shown when dragging a datastore parameter onto the page](/src/assets/datasidebar_wizard.png)
+![The wizard shown when dragging a datastore variable onto the page](/src/assets/datasidebar_wizard.png)
 
 The wizard will try and pick the best component for the type of data you dragged onto the page. The component will be added to wherever your dragged it onto the page. It will also set up, where possible, any datasources or form inputs for you.
 
-![The wizard shown when dragging a datastore parameter onto the page](/src/assets/datasidebar_wizard_result.png)
+![The wizard shown when dragging a datastore variable onto the page](/src/assets/datasidebar_wizard_result.png)

--- a/src/projects/automation/datastores/datastores.md
+++ b/src/projects/automation/datastores/datastores.md
@@ -1,12 +1,12 @@
-# Datastores 
+# Datastores
 
 Datastores are storage containers which you can throw almost anything into. They can store tables, files, images, variables, and Identities and they can even securely store passwords.
-Each Automation project can have one or more Datastores inside it. This allows you to keep unrelated variables and data separate from each other and keep everything organized. 
-Datastore parameters are case-sensitive. Datastore parameters refer to variables, passwords, files, Identities and tables. 
+Each Automation project can have one or more Datastores inside it. This allows you to keep unrelated variables and data separate from each other and keep everything organized.
+Datastore variables are case-sensitive.
 
 ### Data from a Datastore
 
-- :docs-link[**Variables**]{id="projects/automation/activities/variables"} - Store a named value with an associated type such as text, number, coordinates, image, etc. 
+- :docs-link[**Variables**]{id="projects/automation/activities/variables"} - Store a named value with an associated type such as text, number, coordinates, image, etc.
 - **Passwords** - Securely store a password, this value is encrypted and won't be logged anywhere. Recommended for credentials or sensitive information
 - **Files** - Persistely store a file so that it can be accessed by automation or apps
 - :docs-link[**Identities**]{id="projects/automation/datastores/identity"} - Link a digital identity so that you can use automation actions on behalf of a user such as sending an email from your Outlook account or uploading a file to your Google Drive

--- a/src/projects/export.md
+++ b/src/projects/export.md
@@ -10,7 +10,7 @@ A project can be exported individually or in relation to an app. It is highly li
 
 ### Datastore Sanitisation
 
-In the event that you would like to export a project but are concerned about sensitive data inside your datastores, you have the option to sanitise them. All datastore parameters i.e variables, tables, will have their data replaced with anonymised auto-generated data of the same type.
+In the event that you would like to export a project but are concerned about sensitive data inside your datastores, you have the option to sanitise them. All datastore variables i.e variables, tables, will have their data replaced with anonymised auto-generated data of the same type.
 
 ### Select Datastores to Export without Table Data
 


### PR DESCRIPTION
Following discussion across the team, it's been decided that 'Datastore Variable' is a more understood term than `Datastore Parameter`.

This PR changes the terminology across the docs, and removes one sentence that no longer makes sense with the new wording.