### PR TITLE
Cherry Pick: Add default sources and keyword sources for Toca Docs AI…

### DIFF
--- a/.toca/tocabot/README.md
+++ b/.toca/tocabot/README.md
@@ -1,0 +1,11 @@
+# .toca/tocabot
+
+This directory powers the [Toca Docs AI Search](../../src/common/documentation_ai.md) functionality.
+
+- `default_sources.json`: This file specifies which docs are provided to the AI for **every query**, regardless of the user's context. It should include broadly relevant documents that are useful to provide context for most queries.
+
+- `keyword_sources.json`: This file specifies which docs are provided to the AI based on the words in a user's query. It should include documents that are relevant to specific keywords or phrases that users might search for.
+
+The format of these sources is the same `:docs-link[]` format we use throughout the docs (see [Linking to other docs](../../README.md#linking-to-other-docs)). This means you can include `Platform`, `Action`, `Connector`, `AppAction`, and `AppComponent` docs as sources.
+
+> **Note:** In addition to these files, the AI also dynamically fetches docs based on their semantic similarity to the user's query. This means that even if a document is not explicitly listed in either `default_sources.json` or `keyword_sources.json`, it can still be included in the AI's response if it is contextually relevant.

--- a/.toca/tocabot/default_sources.json
+++ b/.toca/tocabot/default_sources.json
@@ -1,0 +1,3 @@
+[
+  ":docs-link[What Toca is]{id=\"book/getting_started/hello_toca\"}"
+]

--- a/.toca/tocabot/keyword_sources.json
+++ b/.toca/tocabot/keyword_sources.json
@@ -1,0 +1,9 @@
+[
+  {
+    "keywords": ["table", "tables"],
+    "sources": [
+      ":docs-link[Datastores]{id=\"projects/automation/datastores/datastores\"}",
+      ":docs-link[Get Table Information]{id=\"GetTableInfo\" type=\"Action\"}"
+    ]
+  }
+]


### PR DESCRIPTION


    Add new .toca/tocabot files to power the Toca Docs AI.
    This currently just has a couple basic keyword / default sources as a proof of concept, to facilitate development.

