### PR TITLE
Include Table Component when AI query contains 'table' or 'tables'

### DIFF
--- a/.toca/tocabot/keyword_sources.json
+++ b/.toca/tocabot/keyword_sources.json
@@ -3,7 +3,8 @@
     "keywords": ["table", "tables"],
     "sources": [
       ":docs-link[Datastores]{id=\"projects/automation/datastores/datastores\"}",
-      ":docs-link[Get Table Information]{id=\"GetTableInfo\" type=\"Action\"}"
+      ":docs-link[Get Table Information]{id=\"GetTableInfo\" type=\"Action\"}",
+      ":docs-link[Table Component]{id=\"e6909eed-aa24-48c1-8de7-bc02f23896d6\" type=\"AppComponent\"}"
     ]
   }
 ]


### PR DESCRIPTION
We have so many app actions, actions, etc that mention tables which means searching 'how do I display a table' doesn't typically retrieve the table component as a source. This PR ensures it will always be included.